### PR TITLE
Add Python refactor pipeline with DIP client and Gemini integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -198,6 +198,17 @@ PublishScripts/
 
 # Microsoft Azure Build Output
 csx/
+# Python virtual environments and caches
+.venv/
+venv/
+env/
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+pip-wheel-metadata/
+*.egg-info/
+
 *.build.csdef
 
 # Microsoft Azure Emulator

--- a/bundestag_mine_refactor/README.md
+++ b/bundestag_mine_refactor/README.md
@@ -1,0 +1,95 @@
+# Bundestags-Mine Refactor (Python 2025)
+
+Diese Codebasis bildet den modernen Kern der Bundestags-Mine Pipeline in Python.
+Sie ersetzt die ursprünglichen .NET- und Java-Komponenten durch ein schlankes
+Setup, das alle Verarbeitungsschritte – Datenabruf, Parsing, Persistenz und
+KI-Auswertung – aus einer Hand übernimmt.
+
+## Ziele
+
+* Zugriff auf den Bundestags-Datenservice (DIP) ausschließlich per offizieller
+  REST-API.
+* Zerlegung der Plenarprotokolle in strukturierte Redebeiträge.
+* Persistente Speicherung in einer lokalen SQLite-Datenbank ohne zusätzliche
+  Token- oder Statistiktabellen.
+* KI-gestützte Zusammenfassungen jeder Rede über die Gemini 2.5 Pro API.
+
+## Projektstruktur
+
+```
+bundestag_mine_refactor/
+├── bundestag_mine_refactor/
+│   ├── cli.py              # Kommandozeilen-Einstieg
+│   ├── config.py           # Konfiguration (Datei + Umgebungsvariablen)
+│   ├── dip_client.py       # Zugriff auf die DIP REST-API
+│   ├── models.py           # SQLAlchemy-ORM-Modelle
+│   ├── parser.py           # Zerlegung von Protokollen in Reden
+│   ├── pipeline.py         # Orchestrierung Import + Summaries
+│   ├── storage.py          # SQLite Persistence Layer
+│   ├── summarizer.py       # Gemini 2.5 Pro Integration
+│   ├── types.py            # Domänen-Dataclasses
+│   └── __main__.py         # `python -m bundestag_mine_refactor`
+├── pyproject.toml          # Projekt-Metadaten & Abhängigkeiten
+└── tests/                  # Pytest-basierte Einheiten-Tests
+```
+
+## Installation
+
+```bash
+cd bundestag_mine_refactor
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .[dev]
+```
+
+## Konfiguration
+
+Die Anwendung liest Konfigurationen aus einer optionalen JSON-Datei
+(`bundestag_mine_refactor.json` im Projektroot oder `~/.config/bundestag_mine_refactor/config.json`)
+und aus Umgebungsvariablen mit dem Präfix `BMR_`.
+
+Wichtige Variablen:
+
+* `BMR_DIP_API_KEY` – Schlüssel für die DIP-API.
+* `BMR_STORAGE_DATABASE_URL` – Pfad zur SQLite-Datei (Standard: `sqlite:///bundestag_mine.db`).
+* `BMR_GEMINI_API_KEY` – Schlüssel für die Gemini 2.5 Pro API.
+* `BMR_GEMINI_MODEL` – Modellname (Standard `gemini-2.5-pro`).
+
+## Nutzung
+
+Protokolle importieren und direkt zusammenfassen:
+
+```bash
+bundestag-mine-refactor import --limit 5
+```
+
+Nur neue Protokolle seit einem Timestamp laden:
+
+```bash
+bundestag-mine-refactor import --since 2024-05-01T00:00:00
+```
+
+Summaries deaktivieren (z. B. bei fehlendem API-Key):
+
+```bash
+bundestag-mine-refactor import --without-summaries
+```
+
+Die Pipeline erzeugt eine SQLite-Datenbank `bundestag_mine.db`, in der
+Plenarprotokolle (`protocols`) und Reden (`speeches`) inklusive KI-Output
+abgelegt werden.
+
+## Tests
+
+```bash
+pytest
+```
+
+Die enthaltenen Tests prüfen u. a. das Parsing deutscher Protokolle und die
+Interpretation der DIP-Metadaten.
+
+## Ausblick
+
+* Ergänzung einer HTML-Report-Generierung für lokale Auswertungen.
+* Erweiterte KI-Aufrufe (Sentiment, Topics) über optionale Prompts.
+* Zusätzliche Qualitätschecks für sehr große Reden (Chunking-Strategie).

--- a/bundestag_mine_refactor/bundestag_mine_refactor/__main__.py
+++ b/bundestag_mine_refactor/bundestag_mine_refactor/__main__.py
@@ -1,0 +1,8 @@
+"""Entry point for ``python -m bundestag_mine_refactor``."""
+from __future__ import annotations
+
+from .cli import main
+
+
+if __name__ == "__main__":  # pragma: no cover - module entry point
+    raise SystemExit(main())

--- a/bundestag_mine_refactor/bundestag_mine_refactor/cli.py
+++ b/bundestag_mine_refactor/bundestag_mine_refactor/cli.py
@@ -1,0 +1,71 @@
+"""Command line interface for controlling the refactored pipeline."""
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+from typing import Optional
+
+from .config import AppConfig, load_config
+from .dip_client import DIPClient
+from .pipeline import ImportPipeline
+from .storage import create_storage
+from .summarizer import GeminiSummarizer
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(name)s: %(message)s")
+LOGGER = logging.getLogger(__name__)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Bundestags-Mine refactored pipeline controller")
+    parser.add_argument("command", choices=["import"], help="Which pipeline action to execute")
+    parser.add_argument("--config", type=Path, help="Path to an explicit configuration file")
+    parser.add_argument("--since", dest="updated_since", help="Only fetch protocols updated since this ISO timestamp")
+    parser.add_argument("--limit", type=int, help="Maximum number of protocols to import")
+    parser.add_argument(
+        "--without-summaries",
+        action="store_true",
+        help="Skip Gemini summarisation even if an API key is configured",
+    )
+    return parser
+
+
+def _create_pipeline(config: AppConfig, *, skip_summaries: bool) -> ImportPipeline:
+    dip_client = DIPClient(
+        config.dip.base_url,
+        config.dip.api_key,
+        timeout=config.dip.timeout,
+        max_retries=config.dip.max_retries,
+        page_size=config.dip.page_size,
+    )
+    storage = create_storage(config.storage.database_url, echo=config.storage.echo_sql)
+    summarizer = None
+    if not skip_summaries and config.gemini.api_key:
+        summarizer = GeminiSummarizer(
+            api_key=config.gemini.api_key,
+            base_url=config.gemini.base_url,
+            model=config.gemini.model,
+            timeout=config.gemini.timeout,
+            max_retries=config.gemini.max_retries,
+        )
+    elif not skip_summaries:
+        LOGGER.warning("Gemini API key missing - summaries will be skipped")
+    return ImportPipeline(dip_client=dip_client, storage=storage, summarizer=summarizer)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    config = load_config(args.config)
+    pipeline = _create_pipeline(config, skip_summaries=args.without_summaries)
+
+    if args.command == "import":
+        processed = pipeline.run(updated_since=args.updated_since, limit=args.limit)
+        LOGGER.info("Imported %s protocols", processed)
+        return 0
+    parser.error(f"Unknown command {args.command}")
+    return 2
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/bundestag_mine_refactor/bundestag_mine_refactor/config.py
+++ b/bundestag_mine_refactor/bundestag_mine_refactor/config.py
@@ -1,0 +1,118 @@
+"""Application configuration helpers for the refactored Bundestags-Mine pipeline."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+import json
+import os
+
+
+_DEFAULT_CONFIG_LOCATIONS = (
+    Path("bundestag_mine_refactor.json"),
+    Path.home() / ".config" / "bundestag_mine_refactor" / "config.json",
+)
+
+
+@dataclass(slots=True)
+class DIPConfig:
+    """Configuration for the Bundestag DIP API."""
+
+    base_url: str = "https://search.dip.bundestag.de/api/v1"
+    api_key: Optional[str] = None
+    timeout: float = 30.0
+    max_retries: int = 3
+    page_size: int = 100
+
+
+@dataclass(slots=True)
+class GeminiConfig:
+    """Configuration for the Gemini 2.5 Pro API."""
+
+    api_key: Optional[str] = None
+    base_url: str = "https://generativelanguage.googleapis.com"
+    model: str = "gemini-2.5-pro"
+    timeout: float = 120.0
+    max_retries: int = 3
+    enable_safety_settings: bool = True
+
+
+@dataclass(slots=True)
+class StorageConfig:
+    """Configuration for the local SQLite database."""
+
+    database_url: str = "sqlite:///bundestag_mine.db"
+    echo_sql: bool = False
+
+
+@dataclass(slots=True)
+class AppConfig:
+    """High level application configuration."""
+
+    dip: DIPConfig
+    gemini: GeminiConfig
+    storage: StorageConfig
+
+
+def _load_from_env(prefix: str) -> Dict[str, Any]:
+    """Load configuration entries for ``prefix`` from the environment."""
+
+    data: Dict[str, Any] = {}
+    for key, value in os.environ.items():
+        if key.startswith(prefix):
+            normalized_key = key.removeprefix(prefix)
+            data[normalized_key.lower()] = value
+    return data
+
+
+def _merge_dict(target: Dict[str, Any], updates: Dict[str, Any]) -> Dict[str, Any]:
+    merged = target.copy()
+    merged.update({k: v for k, v in updates.items() if v is not None})
+    return merged
+
+
+def _load_config_file(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        return {}
+    with path.open("r", encoding="utf8") as fh:
+        return json.load(fh)
+
+
+def load_config(explicit_path: Optional[Path] = None) -> AppConfig:
+    """Create the application configuration.
+
+    The function combines default values, optional configuration files and
+    environment variables (``BMR_*``) into a single :class:`AppConfig` instance.
+    Environment variable names are expected to use the format
+    ``BMR_SECTION_FIELD`` (e.g. ``BMR_DIP_API_KEY``).
+    """
+
+    base = {
+        "dip": DIPConfig().__dict__,
+        "gemini": GeminiConfig().__dict__,
+        "storage": StorageConfig().__dict__,
+    }
+
+    file_data: Dict[str, Any] = {}
+    if explicit_path:
+        file_data = _load_config_file(explicit_path)
+    else:
+        for candidate in _DEFAULT_CONFIG_LOCATIONS:
+            file_data = _load_config_file(candidate)
+            if file_data:
+                break
+
+    merged = _merge_dict(base, file_data)
+
+    dip_data = _merge_dict(merged.get("dip", {}), _load_from_env("BMR_DIP_"))
+    gemini_data = _merge_dict(merged.get("gemini", {}), _load_from_env("BMR_GEMINI_"))
+    storage_data = _merge_dict(merged.get("storage", {}), _load_from_env("BMR_STORAGE_"))
+
+    return AppConfig(
+        dip=DIPConfig(**dip_data),
+        gemini=GeminiConfig(**gemini_data),
+        storage=StorageConfig(**storage_data),
+    )
+
+
+__all__ = ["AppConfig", "DIPConfig", "GeminiConfig", "StorageConfig", "load_config"]

--- a/bundestag_mine_refactor/bundestag_mine_refactor/dip_client.py
+++ b/bundestag_mine_refactor/bundestag_mine_refactor/dip_client.py
@@ -1,0 +1,131 @@
+"""HTTP client for the Bundestag Data Service (DIP) API."""
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Dict, Iterator, Optional
+import logging
+
+import httpx
+
+from .types import ProtocolDocument, ProtocolMetadata
+
+LOGGER = logging.getLogger(__name__)
+
+
+class DIPClientError(RuntimeError):
+    """Raised when the Bundestag DIP API responds with an error."""
+
+
+class DIPClient:
+    """Minimal client for fetching plenary protocols from DIP."""
+
+    def __init__(
+        self,
+        base_url: str,
+        api_key: Optional[str],
+        *,
+        timeout: float = 30.0,
+        max_retries: int = 3,
+        page_size: int = 100,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._api_key = api_key
+        self._max_retries = max(1, max_retries)
+        self._page_size = page_size
+        self._client = httpx.Client(timeout=timeout)
+
+    # --- public API -----------------------------------------------------
+    def iter_protocols(self, *, updated_since: Optional[str] = None) -> Iterator[ProtocolMetadata]:
+        """Iterate over protocol metadata entries."""
+
+        page = 0
+        while True:
+            params: Dict[str, str] = {"offset": str(page * self._page_size), "limit": str(self._page_size)}
+            if updated_since:
+                params["f.aktualisiertStart"] = updated_since
+            response_json = self._request("GET", "/plenarprotokoll", params=params)
+            documents = response_json.get("documents") or response_json.get("dokuments") or []
+            if not documents:
+                break
+            for entry in documents:
+                yield self._parse_protocol_metadata(entry)
+            if len(documents) < self._page_size:
+                break
+            page += 1
+
+    def fetch_protocol_text(self, identifier: str) -> ProtocolDocument:
+        """Download a plenary protocol including the full text."""
+
+        endpoint = f"/plenarprotokoll-text/{identifier}"
+        data = self._request("GET", endpoint)
+        metadata = self._parse_protocol_metadata(data)
+        full_text = data.get("text") or data.get("inhalt")
+        if not full_text:
+            raise DIPClientError(f"Protocol {identifier} does not contain text data")
+        return ProtocolDocument(metadata=metadata, full_text=full_text)
+
+    # --- helpers --------------------------------------------------------
+    def _headers(self) -> Dict[str, str]:
+        headers = {"Accept": "application/json"}
+        if self._api_key:
+            headers["Authorization"] = f"ApiKey {self._api_key}"
+        return headers
+
+    def _request(self, method: str, path: str, params: Optional[Dict[str, str]] = None) -> Dict[str, any]:
+        url = f"{self._base_url}{path}"
+        last_exc: Optional[Exception] = None
+        for attempt in range(1, self._max_retries + 1):
+            try:
+                response = self._client.request(method, url, headers=self._headers(), params=params)
+                response.raise_for_status()
+                return response.json()
+            except httpx.HTTPStatusError as exc:  # pragma: no cover - network errors are rare in tests
+                last_exc = exc
+                LOGGER.warning("DIP API returned status %s for %s %s", exc.response.status_code, method, url)
+            except httpx.HTTPError as exc:  # pragma: no cover - network errors are rare in tests
+                last_exc = exc
+                LOGGER.warning("HTTP error while requesting %s %s: %s", method, url, exc)
+        raise DIPClientError(f"Failed to request {url}") from last_exc
+
+    @staticmethod
+    def _parse_protocol_metadata(data: Dict[str, any]) -> ProtocolMetadata:
+        raw_identifier = data.get("id") or data.get("vorgangId") or data.get("dipId") or data.get("plenarprotokollId")
+        if not raw_identifier:
+            raise DIPClientError("Protocol metadata did not contain an identifier")
+        identifier = str(raw_identifier)
+
+        def _parse_int(candidate: Optional[str]) -> Optional[int]:
+            if candidate is None:
+                return None
+            try:
+                return int(candidate)
+            except (TypeError, ValueError):
+                return None
+
+        def _parse_date(value: Optional[str]) -> Optional[date]:
+            if not value:
+                return None
+            try:
+                return datetime.fromisoformat(value).date()
+            except ValueError:
+                try:
+                    return datetime.strptime(value, "%d.%m.%Y").date()
+                except ValueError:
+                    return None
+
+        legislative_period = _parse_int(data.get("wahlperiode") or data.get("wahlperiodeNummer"))
+        session_number = _parse_int(data.get("sitzungsnummer") or data.get("nummer"))
+        date_value = _parse_date(data.get("datum") or data.get("sitzungsdatum"))
+        title = data.get("titel") or data.get("sitzungstitel")
+
+        return ProtocolMetadata(
+            identifier=identifier,
+            legislative_period=legislative_period,
+            session_number=session_number,
+            date=date_value,
+            title=title,
+            source=data,
+        )
+
+
+__all__ = ["DIPClient", "DIPClientError"]

--- a/bundestag_mine_refactor/bundestag_mine_refactor/models.py
+++ b/bundestag_mine_refactor/bundestag_mine_refactor/models.py
@@ -1,0 +1,58 @@
+"""SQLAlchemy models for the refactored Bundestags-Mine pipeline."""
+from __future__ import annotations
+
+from datetime import datetime, date
+from typing import List, Optional
+
+from sqlalchemy import Date, DateTime, ForeignKey, Integer, String, Text, func
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+
+
+class Base(DeclarativeBase):
+    """Declarative SQLAlchemy base class."""
+
+
+class Protocol(Base):
+    """Database representation of a plenary protocol."""
+
+    __tablename__ = "protocols"
+
+    id: Mapped[str] = mapped_column(String(128), primary_key=True)
+    legislative_period: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    session_number: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    date: Mapped[Optional[date]] = mapped_column(Date, nullable=True)
+    title: Mapped[Optional[str]] = mapped_column(String(512), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, server_default=func.now(), onupdate=func.now()
+    )
+
+    speeches: Mapped[List["SpeechModel"]] = relationship(
+        back_populates="protocol", cascade="all, delete-orphan"
+    )
+
+
+class SpeechModel(Base):
+    """Database representation of a speech."""
+
+    __tablename__ = "speeches"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    protocol_id: Mapped[str] = mapped_column(String(128), ForeignKey("protocols.id"), index=True)
+    sequence_number: Mapped[int] = mapped_column(Integer, index=True)
+    speaker_name: Mapped[str] = mapped_column(String(256))
+    party: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
+    role: Mapped[Optional[str]] = mapped_column(String(128), nullable=True)
+    text: Mapped[str] = mapped_column(Text)
+    summary: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    sentiment: Mapped[Optional[str]] = mapped_column(String(32), nullable=True)
+    topics: Mapped[Optional[str]] = mapped_column(String(256), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, server_default=func.now(), onupdate=func.now()
+    )
+
+    protocol: Mapped[Protocol] = relationship(back_populates="speeches")
+
+
+__all__ = ["Base", "Protocol", "SpeechModel"]

--- a/bundestag_mine_refactor/bundestag_mine_refactor/parser.py
+++ b/bundestag_mine_refactor/bundestag_mine_refactor/parser.py
@@ -1,0 +1,87 @@
+"""Utilities for parsing plenary protocol texts into speeches."""
+from __future__ import annotations
+
+from typing import List, Tuple
+import logging
+import re
+
+from .types import Speech
+
+LOGGER = logging.getLogger(__name__)
+
+_SPEAKER_PATTERN = re.compile(
+    r"^\s*(?P<header>[A-ZÄÖÜß][^\n:]{2,}?)(?::|\s+:)",
+    re.MULTILINE,
+)
+_PARTY_PATTERN = re.compile(r"\((?P<party>[^)]+)\)")
+_ROLE_KEYWORDS = (
+    r"Präsident(?:in)?",
+    r"Vizepräsident(?:in)?",
+    r"Bundesminister(?:in)?",
+    r"Bundeskanzler(?:in)?",
+    r"Staatssekretär(?:in)?",
+    r"Staatsminister(?:in)?",
+    r"Parlamentarische(?:r)?\s+Staatssekretär(?:in)?",
+)
+_STAGE_DIRECTIONS = re.compile(
+    r"\((?:[^()]*?(?:Beifall|Zuruf|Heiterkeit|Lachen|Unruhe|Beifallsrufe)[^()]*)\)",
+    re.IGNORECASE,
+)
+_MULTISPACE = re.compile(r"\s{2,}")
+_INTERJECTION_PATTERN = re.compile(r"^Zuruf von [^\n:]+:.*$", re.MULTILINE)
+
+
+def _extract_party(header: str) -> Tuple[str, str | None]:
+    match = _PARTY_PATTERN.search(header)
+    if not match:
+        return header.strip(), None
+    party = match.group("party").strip()
+    cleaned = _PARTY_PATTERN.sub("", header).strip()
+    return cleaned, party
+
+
+def _split_role(name: str) -> Tuple[str, str | None]:
+    for keyword in _ROLE_KEYWORDS:
+        pattern = re.compile(rf"^(?P<role>{keyword}\b[^:]*?)\s+(?P<name>.+)$", re.IGNORECASE)
+        match = pattern.match(name)
+        if match:
+            return match.group("name").strip(), match.group("role").strip()
+    return name.strip(), None
+
+
+def parse_speeches(protocol_text: str, protocol_id: str) -> List[Speech]:
+    """Parse the speech segments contained in ``protocol_text``."""
+
+    cleaned_text = _INTERJECTION_PATTERN.sub("", protocol_text)
+    matches = list(_SPEAKER_PATTERN.finditer(cleaned_text))
+    speeches: List[Speech] = []
+    if not matches:
+        LOGGER.warning("No speeches detected for protocol %s", protocol_id)
+        return speeches
+
+    for index, match in enumerate(matches):
+        start = match.end()
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(cleaned_text)
+        raw_header = match.group("header").strip()
+        raw_text = cleaned_text[start:end].strip()
+        raw_text = _STAGE_DIRECTIONS.sub("", raw_text)
+        raw_text = _MULTISPACE.sub(" ", raw_text)
+        header_without_party, party = _extract_party(raw_header)
+        speaker_name, role = _split_role(header_without_party)
+        speech_text = raw_text.strip()
+        if not speech_text:
+            continue
+        speeches.append(
+            Speech(
+                protocol_id=protocol_id,
+                sequence_number=index + 1,
+                speaker_name=speaker_name,
+                party=party,
+                role=role,
+                text=speech_text,
+            )
+        )
+    return speeches
+
+
+__all__ = ["parse_speeches"]

--- a/bundestag_mine_refactor/bundestag_mine_refactor/pipeline.py
+++ b/bundestag_mine_refactor/bundestag_mine_refactor/pipeline.py
@@ -1,0 +1,54 @@
+"""High level orchestration of the refactored Bundestags-Mine pipeline."""
+from __future__ import annotations
+
+from typing import Optional
+import logging
+
+from .dip_client import DIPClient
+from .parser import parse_speeches
+from .storage import Storage
+from .summarizer import GeminiSummarizer
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ImportPipeline:
+    """Complete workflow for fetching, parsing and storing protocols."""
+
+    def __init__(
+        self,
+        *,
+        dip_client: DIPClient,
+        storage: Storage,
+        summarizer: Optional[GeminiSummarizer] = None,
+    ) -> None:
+        self._dip_client = dip_client
+        self._storage = storage
+        self._summarizer = summarizer
+
+    def run(self, *, updated_since: Optional[str] = None, limit: Optional[int] = None) -> int:
+        """Run the pipeline end-to-end."""
+
+        processed = 0
+        for metadata in self._dip_client.iter_protocols(updated_since=updated_since):
+            if limit is not None and processed >= limit:
+                break
+            LOGGER.info("Processing protocol %s", metadata.identifier)
+            document = self._dip_client.fetch_protocol_text(metadata.identifier)
+            self._storage.upsert_protocol(document.metadata)
+            speeches = parse_speeches(document.full_text, document.metadata.identifier)
+            self._storage.replace_speeches(document.metadata.identifier, speeches)
+            if self._summarizer:
+                self._summarize_pending()
+            processed += 1
+        return processed
+
+    def _summarize_pending(self) -> None:
+        assert self._summarizer is not None
+        pending = self._storage.pending_summaries(limit=25)
+        for speech in pending:
+            summary = self._summarizer.summarize(speech.text)
+            self._storage.update_summary(speech.id, summary=summary)
+
+
+__all__ = ["ImportPipeline"]

--- a/bundestag_mine_refactor/bundestag_mine_refactor/storage.py
+++ b/bundestag_mine_refactor/bundestag_mine_refactor/storage.py
@@ -1,0 +1,101 @@
+"""Persistence helpers built on SQLAlchemy."""
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Iterable, Iterator, Sequence
+
+from sqlalchemy import create_engine, select
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from .models import Base, Protocol, SpeechModel
+from .types import ProtocolMetadata, Speech
+
+
+class Storage:
+    """Wrapper around SQLAlchemy to store protocols and speeches."""
+
+    def __init__(self, engine: Engine) -> None:
+        self._engine = engine
+        self._session_factory = sessionmaker(bind=engine, expire_on_commit=False)
+
+    @contextmanager
+    def session(self) -> Iterator[Session]:
+        session = self._session_factory()
+        try:
+            yield session
+            session.commit()
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+    def ensure_schema(self) -> None:
+        Base.metadata.create_all(self._engine)
+
+    def upsert_protocol(self, metadata: ProtocolMetadata) -> Protocol:
+        with self.session() as session:
+            protocol = session.get(Protocol, metadata.identifier)
+            if protocol is None:
+                protocol = Protocol(
+                    id=metadata.identifier,
+                    legislative_period=metadata.legislative_period,
+                    session_number=metadata.session_number,
+                    date=metadata.date,
+                    title=metadata.title,
+                )
+                session.add(protocol)
+                session.flush()
+            else:
+                protocol.legislative_period = metadata.legislative_period
+                protocol.session_number = metadata.session_number
+                protocol.date = metadata.date
+                protocol.title = metadata.title
+            return protocol
+
+    def replace_speeches(self, protocol_id: str, speeches: Sequence[Speech]) -> int:
+        with self.session() as session:
+            protocol = session.get(Protocol, protocol_id)
+            if protocol is None:
+                raise ValueError(f"Protocol {protocol_id} must exist before adding speeches")
+            session.query(SpeechModel).filter(SpeechModel.protocol_id == protocol_id).delete()
+            for speech in speeches:
+                speech_model = SpeechModel(
+                    protocol_id=protocol_id,
+                    sequence_number=speech.sequence_number,
+                    speaker_name=speech.speaker_name,
+                    party=speech.party,
+                    role=speech.role,
+                    text=speech.text,
+                    summary=speech.summary,
+                    sentiment=speech.sentiment,
+                    topics=speech.topics,
+                )
+                session.add(speech_model)
+            session.flush()
+            return len(speeches)
+
+    def pending_summaries(self, limit: int = 50) -> Iterable[SpeechModel]:
+        with self.session() as session:
+            stmt = select(SpeechModel).where(SpeechModel.summary.is_(None)).order_by(SpeechModel.id).limit(limit)
+            return list(session.scalars(stmt))
+
+    def update_summary(self, speech_id: int, *, summary: str, sentiment: str | None = None, topics: str | None = None) -> None:
+        with self.session() as session:
+            speech = session.get(SpeechModel, speech_id)
+            if speech is None:
+                raise ValueError(f"Speech {speech_id} not found")
+            speech.summary = summary
+            speech.sentiment = sentiment
+            speech.topics = topics
+
+
+def create_storage(database_url: str, *, echo: bool = False) -> Storage:
+    engine = create_engine(database_url, echo=echo, future=True)
+    storage = Storage(engine)
+    storage.ensure_schema()
+    return storage
+
+
+__all__ = ["Storage", "create_storage"]

--- a/bundestag_mine_refactor/bundestag_mine_refactor/summarizer.py
+++ b/bundestag_mine_refactor/bundestag_mine_refactor/summarizer.py
@@ -1,0 +1,77 @@
+"""Integration with the Gemini 2.5 Pro API."""
+from __future__ import annotations
+
+from typing import Optional
+import logging
+
+import httpx
+
+LOGGER = logging.getLogger(__name__)
+
+_PROMPT_TEMPLATE = (
+    "Fasse die folgende Rede aus dem Deutschen Bundestag sachlich, kompakt "
+    "und in höchstens fünf Sätzen zusammen. Konzentriere dich auf zentrale "
+    "Argumente, Beschlüsse und Forderungen. Rede:\n\n{speech}"
+)
+
+
+class GeminiSummarizer:
+    """Client for the Gemini 2.5 Pro text summarisation endpoint."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        base_url: str = "https://generativelanguage.googleapis.com",
+        model: str = "gemini-2.5-pro",
+        timeout: float = 120.0,
+        max_retries: int = 3,
+    ) -> None:
+        if not api_key:
+            raise ValueError("A Gemini API key must be provided")
+        self._api_key = api_key
+        self._base_url = base_url.rstrip("/")
+        self._model = model
+        self._timeout = timeout
+        self._max_retries = max(1, max_retries)
+
+    def summarize(self, speech_text: str) -> str:
+        """Generate a Gemini powered summary for ``speech_text``."""
+
+        prompt = _PROMPT_TEMPLATE.format(speech=speech_text.strip())
+        payload = {
+            "contents": [
+                {"role": "user", "parts": [{"text": prompt}]}
+            ],
+            "generationConfig": {
+                "temperature": 0.2,
+                "topK": 32,
+                "topP": 0.95,
+                "maxOutputTokens": 512,
+            },
+        }
+        endpoint = f"{self._base_url}/v1beta/models/{self._model}:generateContent?key={self._api_key}"
+        last_exc: Optional[Exception] = None
+        for attempt in range(1, self._max_retries + 1):
+            try:
+                response = httpx.post(endpoint, json=payload, timeout=self._timeout)
+                response.raise_for_status()
+                data = response.json()
+                return self._extract_text(data)
+            except httpx.HTTPError as exc:  # pragma: no cover - network errors are rare in tests
+                last_exc = exc
+                LOGGER.warning("Gemini request failed (attempt %s/%s): %s", attempt, self._max_retries, exc)
+        raise RuntimeError("Failed to generate summary via Gemini") from last_exc
+
+    @staticmethod
+    def _extract_text(response_json: dict) -> str:
+        candidates = response_json.get("candidates") or []
+        for candidate in candidates:
+            for part in candidate.get("content", {}).get("parts", []):
+                text = part.get("text")
+                if text:
+                    return text.strip()
+        raise RuntimeError("Gemini response did not contain text")
+
+
+__all__ = ["GeminiSummarizer"]

--- a/bundestag_mine_refactor/bundestag_mine_refactor/types.py
+++ b/bundestag_mine_refactor/bundestag_mine_refactor/types.py
@@ -1,0 +1,44 @@
+"""Typed domain objects for the refactored pipeline."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date
+from typing import Any, Dict, Optional
+
+
+@dataclass(slots=True)
+class ProtocolMetadata:
+    """Metadata describing a Bundestag plenary protocol."""
+
+    identifier: str
+    legislative_period: Optional[int]
+    session_number: Optional[int]
+    date: Optional[date]
+    title: Optional[str]
+    source: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class ProtocolDocument:
+    """A protocol document including the full text."""
+
+    metadata: ProtocolMetadata
+    full_text: str
+
+
+@dataclass(slots=True)
+class Speech:
+    """A single speech contribution within a protocol."""
+
+    protocol_id: str
+    sequence_number: int
+    speaker_name: str
+    text: str
+    party: Optional[str] = None
+    role: Optional[str] = None
+    topics: Optional[str] = None
+    summary: Optional[str] = None
+    sentiment: Optional[str] = None
+
+
+__all__ = ["ProtocolMetadata", "ProtocolDocument", "Speech"]

--- a/bundestag_mine_refactor/pyproject.toml
+++ b/bundestag_mine_refactor/pyproject.toml
@@ -1,0 +1,18 @@
+[project]
+name = "bundestag-mine-refactor"
+version = "0.1.0"
+description = "Modernisierte Python-Pipeline für Bundestagsprotokolle"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "httpx>=0.27",
+    "SQLAlchemy>=2.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0",
+]
+
+[project.scripts]
+bundestag-mine-refactor = "bundestag_mine_refactor.cli:main"

--- a/bundestag_mine_refactor/requirements.txt
+++ b/bundestag_mine_refactor/requirements.txt
@@ -1,0 +1,2 @@
+httpx>=0.27
+SQLAlchemy>=2.0

--- a/bundestag_mine_refactor/tests/test_dip_client.py
+++ b/bundestag_mine_refactor/tests/test_dip_client.py
@@ -1,0 +1,35 @@
+from datetime import date
+from datetime import date
+
+import pytest
+
+from bundestag_mine_refactor.dip_client import DIPClient
+
+
+class DummyClient(DIPClient):
+    def __init__(self):
+        super().__init__(base_url="https://example.invalid", api_key=None)
+
+
+def test_parse_protocol_metadata_handles_multiple_field_names():
+    client = DummyClient()
+    raw = {
+        "id": "BT-PL-20-10",
+        "wahlperiode": "20",
+        "nummer": "10",
+        "datum": "2024-05-05",
+        "titel": "20. Sitzung",
+    }
+
+    metadata = client._parse_protocol_metadata(raw)
+    assert metadata.identifier == "BT-PL-20-10"
+    assert metadata.legislative_period == 20
+    assert metadata.session_number == 10
+    assert metadata.date == date(2024, 5, 5)
+    assert metadata.title == "20. Sitzung"
+
+
+def test_parse_protocol_metadata_requires_identifier():
+    client = DummyClient()
+    with pytest.raises(Exception):
+        client._parse_protocol_metadata({})

--- a/bundestag_mine_refactor/tests/test_parser.py
+++ b/bundestag_mine_refactor/tests/test_parser.py
@@ -1,0 +1,32 @@
+from bundestag_mine_refactor.parser import parse_speeches
+
+
+def test_parse_speeches_extracts_multiple_segments():
+    text = (
+        "Eröffnung der Sitzung\n"
+        "Präsidentin Bärbel Bas:\n"
+        "Guten Tag, ich eröffne die Sitzung.\n"
+        "\n"
+        "Dr. Marco Buschmann (FDP):\n"
+        "Wir beraten heute wichtige Gesetzesinitiativen. (Beifall)\n"
+        "\n"
+        "Zuruf von der SPD: Das sehen wir auch so!\n"
+        "\n"
+        "Bundesministerin Annalena Baerbock:\n"
+        "Außenpolitisch stehen wir vor großen Herausforderungen.\n"
+    )
+
+    speeches = parse_speeches(text, "TEST-1")
+
+    assert len(speeches) == 3
+    assert speeches[0].speaker_name == "Bärbel Bas"
+    assert speeches[0].role == "Präsidentin"
+    assert speeches[0].party is None
+    assert "eröffne die Sitzung" in speeches[0].text
+
+    assert speeches[1].speaker_name == "Dr. Marco Buschmann"
+    assert speeches[1].party == "FDP"
+    assert "Beifall" not in speeches[1].text
+
+    assert speeches[2].speaker_name == "Annalena Baerbock"
+    assert speeches[2].role == "Bundesministerin"


### PR DESCRIPTION
## Summary
- add a new `bundestag_mine_refactor` Python package with configuration, DIP API access, parsing logic, SQLAlchemy storage, and Gemini-powered summarisation
- provide a CLI entry point, packaging metadata, and documentation for running the refactored pipeline
- cover the parser and metadata helpers with pytest-based unit tests and update the ignore list for Python artefacts

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca72b7b8288322868fcad2767a1ab4