### PR TITLE
Use Google GenAI SDK for Gemini summarization

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ requires-python = ">=3.10"
 dependencies = [
     "httpx>=0.27",
     "SQLAlchemy>=2.0",
+    "google-genai>=1.38",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 httpx>=0.27
 SQLAlchemy>=2.0
+google-genai>=1.38

--- a/src/bundestag_mine_refactor/cli.py
+++ b/src/bundestag_mine_refactor/cli.py
@@ -47,6 +47,7 @@ def _create_pipeline(config: AppConfig, *, skip_summaries: bool) -> ImportPipeli
             model=config.gemini.model,
             timeout=config.gemini.timeout,
             max_retries=config.gemini.max_retries,
+            enable_safety_settings=config.gemini.enable_safety_settings,
         )
     elif not skip_summaries:
         LOGGER.warning("Gemini API key missing - summaries will be skipped")


### PR DESCRIPTION
## Summary
- switch the Gemini summarizer to the official `google-genai` client, including configurable safety settings
- wire the CLI to pass the safety toggle and configure HTTP options for the SDK
- declare the new dependency in the project metadata and requirements list

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca894c90048322a755b79c32eb7a05