### PR TITLE
Align DIP client with cursor pagination and harden optional deps

### DIFF
--- a/tests/clients/test_dip_client.py
+++ b/tests/clients/test_dip_client.py
@@ -10,6 +10,27 @@ class DummyClient(DIPClient):
         super().__init__(base_url="https://example.invalid", api_key=None)
 
 
+def test_iter_protocols_uses_cursor(monkeypatch):
+    client = DummyClient()
+
+    responses = [
+        {"documents": [{"id": "BT-PL-1"}], "cursor": "abc"},
+        {"documents": [{"id": "BT-PL-2"}], "cursor": "abc"},
+    ]
+    captured_params = []
+
+    def fake_request(method, path, params=None):
+        captured_params.append(params or {})
+        return responses.pop(0)
+
+    monkeypatch.setattr(client, "_request", fake_request)
+
+    identifiers = [metadata.identifier for metadata in client.iter_protocols()]
+
+    assert identifiers == ["BT-PL-1", "BT-PL-2"]
+    assert captured_params == [{}, {"cursor": "abc"}]
+
+
 def test_parse_protocol_metadata_handles_multiple_field_names():
     client = DummyClient()
     raw = {


### PR DESCRIPTION
## Summary
- switch the DIP client to the documented cursor-based pagination and improve typing
- defer google-genai imports so the package can be imported without the optional dependency installed
- extend DIP client tests to cover cursor handling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ca8b39720c83228f9db45b2c8c1ee5