### PR TITLE
Disable Gemini safety filters by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Erstellen Sie optional eine Datei `bundestag_mine_refactor.json` im Projektverze
 | `BMR_DIP_API_KEY`    | API-Key für das DIP-Portal                      |
 | `BMR_DIP_BASE_URL`   | Alternative Basis-URL des DIP-API               |
 | `BMR_GEMINI_API_KEY` | API-Key für Gemini 2.5 Pro                      |
+| `BMR_GEMINI_ENABLE_SAFETY_SETTINGS` | `true` aktiviert die Safety-Filter (Standard: aus) |
 | `BMR_STORAGE_DATABASE_URL` | Vollständige SQLAlchemy-URL zur Datenbank |
 | `BMR_STORAGE_ECHO_SQL`     | `true`/`false` für SQL-Debug-Ausgaben      |
 

--- a/src/bundestag_mine_refactor/config/settings.py
+++ b/src/bundestag_mine_refactor/config/settings.py
@@ -36,7 +36,7 @@ class GeminiConfig:
     model: str = "gemini-2.5-pro"
     timeout: float = 120.0
     max_retries: int = 3
-    enable_safety_settings: bool = True
+    enable_safety_settings: bool = False
 
 
 @dataclass(slots=True)

--- a/src/bundestag_mine_refactor/summarization/gemini.py
+++ b/src/bundestag_mine_refactor/summarization/gemini.py
@@ -38,7 +38,7 @@ class GeminiSummarizer:
         model: str = "gemini-2.5-pro",
         timeout: float = 120.0,
         max_retries: int = 3,
-        enable_safety_settings: bool = True,
+        enable_safety_settings: bool = False,
     ) -> None:
         if not api_key:
             raise ValueError("A Gemini API key must be provided")


### PR DESCRIPTION
## Summary
- disable Gemini safety filtering by default so summaries run with BLOCK_NONE thresholds
- adjust the README to document how to re-enable the safety filters via environment variables

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca8e07a8dc8322b0099073f426652a