### PR TITLE
Add UI configuration editor and config persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Nach Updates des Quellcodes genügt innerhalb der aktivierten virtuellen Umgebun
 
 ## Konfiguration
 
-`load_config` kombiniert Standardwerte, optionale JSON-Dateien und Umgebungsvariablen mit dem Präfix `MINE_`. Ohne eigene Einstellungen wird eine lokale SQLite-Datenbank (`mine.db`) verwendet.
+`load_config` kombiniert Standardwerte, optionale JSON-Dateien und Umgebungsvariablen mit dem Präfix `MINE_`. Ohne eigene Einstellungen wird eine lokale SQLite-Datenbank (`mine.db`) verwendet. Über die NiceGUI-Oberfläche (`mine ui`) lassen sich alle Konfigurationseinträge komfortabel bearbeiten; Änderungen werden standardmäßig in `~/.config/mine/config.json` gespeichert.
 
 ### Konfigurationsdatei anlegen
 
@@ -118,7 +118,7 @@ Die Anwendung sucht automatisch nach folgenden Dateien (in dieser Reihenfolge):
 1. `./mine.json`
 2. `~/.config/mine/config.json`
 
-Beispielinhalt:
+Der UI-Editor arbeitet direkt mit dieser JSON-Struktur. Beispielinhalt:
 
 ```json
 {
@@ -158,7 +158,7 @@ Umgebungsvariablen überschreiben Werte aus der Datei. Mit `--config /pfad/zur/d
 Die Installation stellt das Skript `mine` bereit. Zwei Befehle stehen zur Verfügung:
 
 - `mine import` startet den ETL-Lauf.
-- `mine ui` startet die grafische Oberfläche.
+- `mine ui` startet die grafische Oberfläche inklusive Konfigurationseditor.
 
 Häufige Optionen:
 
@@ -183,6 +183,7 @@ Der UI-Befehl startet eine NiceGUI-App (Standard: `http://127.0.0.1:8080`). Die 
 - Log-Tabelle mit Zeitstempeln und Verarbeitungsphasen
 - Snapshot-Tabelle aller gespeicherten Protokolle inklusive Sitzung, Datum und Redeanzahl
 - Einblendung von Fehlern und Laufzeitdauer je Import
+- Formularbasierte Pflege von DIP-, Gemini- und Datenbank-Einstellungen inklusive Persistenz in der JSON-Konfiguration
 
 Die UI greift auf dieselbe Konfiguration wie das CLI zu und verwendet den gemeinsamen `Storage`-Layer. Mit `--ui-host 0.0.0.0` lässt sich die Oberfläche im Netzwerk freigeben.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,7 +45,7 @@ Die lokale SQLite-Datenbank (oder eine alternative SQLAlchemy-Zieldatenbank) bes
 ## Konfigurationsquellen
 
 - **Defaultwerte:** in `config.settings` definiert (z. B. DIP-Basis-URL, SQLite-Datenbank).
-- **JSON-Dateien:** `mine.json` im Projekt oder `~/.config/mine/config.json` für nutzerspezifische Einstellungen.
+- **JSON-Dateien:** `mine.json` im Projekt oder `~/.config/mine/config.json` für nutzerspezifische Einstellungen. Über `save_config` können Änderungen programmatisch bzw. über die UI persistiert werden.
 - **Umgebungsvariablen:** Präfix `MINE_` und Schema `MINE_SECTION_FIELD`. Werte werden typkonvertiert (z. B. `true` → `bool`).
 - **CLI-Parameter:** `--config` erlaubt das Laden einer expliziten Konfigurationsdatei.
 
@@ -56,6 +56,7 @@ Die Quellen werden in der obigen Reihenfolge zusammengeführt; spätere Quellen 
 Die NiceGUI-App (`ui.app`) erstellt eine `PipelineRunner`-Instanz, die Importe in einem Hintergrundthread startet und den UI-Status regelmäßig aktualisiert. Kernbestandteile:
 
 - Steuerkarte mit Eingabefeldern für `--since`, `--limit` und einen Schalter für Gemini-Zusammenfassungen.
+- Formularbasierter Konfigurationseditor für DIP-, Gemini- und Datenbankparameter; Änderungen werden gespeichert und bei Bedarf wird die `Storage`-Instanz neu initialisiert.
 - Live-Monitor mit Status-Badge, Zählern (Protokolle, Reden, Summaries), zuletzt verarbeitetem Protokoll und Laufzeit.
 - Log-Tabelle auf Basis von `PipelineEvent`-Meldungen (max. 200 Einträge, zirkulärer Puffer).
 - Tabelle „Persistierte Protokolle“, gespeist von `Storage.list_protocols()` und per Button aktualisierbar.

--- a/src/mine/cli.py
+++ b/src/mine/cli.py
@@ -6,7 +6,7 @@ import logging
 from pathlib import Path
 from typing import Optional
 
-from .config import load_config
+from .config import load_config, resolve_config_path
 from .database import create_storage
 from .runtime import create_pipeline
 
@@ -43,6 +43,7 @@ def main(argv: Optional[list[str]] = None) -> int:
     parser = _build_parser()
     args = parser.parse_args(argv)
     config = load_config(args.config)
+    config_path = resolve_config_path(args.config)
 
     if args.command == "import":
         resources = create_pipeline(config, skip_summaries=args.without_summaries)
@@ -61,6 +62,7 @@ def main(argv: Optional[list[str]] = None) -> int:
             storage=storage,
             host=args.ui_host,
             port=args.ui_port,
+            config_path=config_path,
         )
         storage.dispose()
         return 0

--- a/src/mine/config/__init__.py
+++ b/src/mine/config/__init__.py
@@ -1,7 +1,15 @@
 """Configuration helpers for the Bundestags-Mine pipeline."""
 from __future__ import annotations
 
-from .settings import AppConfig, DIPConfig, GeminiConfig, StorageConfig, load_config
+from .settings import (
+    AppConfig,
+    DIPConfig,
+    GeminiConfig,
+    StorageConfig,
+    load_config,
+    resolve_config_path,
+    save_config,
+)
 
 __all__ = [
     "AppConfig",
@@ -9,4 +17,6 @@ __all__ = [
     "GeminiConfig",
     "StorageConfig",
     "load_config",
+    "resolve_config_path",
+    "save_config",
 ]

--- a/tests/config/test_settings.py
+++ b/tests/config/test_settings.py
@@ -1,6 +1,17 @@
+import json
+
 import pytest
 
-from mine.config import load_config
+import mine.config.settings as config_settings
+from mine.config import (
+    AppConfig,
+    DIPConfig,
+    GeminiConfig,
+    StorageConfig,
+    load_config,
+    resolve_config_path,
+    save_config,
+)
 
 
 def test_environment_values_are_coerced(monkeypatch):
@@ -24,3 +35,39 @@ def test_invalid_boolean_environment_value_raises(monkeypatch):
 
     with pytest.raises(ValueError):
         load_config()
+
+
+def test_resolve_config_path_prefers_existing_file(tmp_path, monkeypatch):
+    first = tmp_path / "mine.json"
+    second = tmp_path / "config.json"
+    monkeypatch.setattr(config_settings, "_DEFAULT_CONFIG_LOCATIONS", (first, second))
+
+    # without existing files we expect the XDG-style location (second entry)
+    resolved_without_file = resolve_config_path(None)
+    assert resolved_without_file == second
+
+    second.write_text("{}", encoding="utf8")
+    resolved = resolve_config_path(None)
+    assert resolved == second
+    explicit = resolve_config_path(first)
+    assert explicit == first
+
+
+def test_save_config_writes_json(tmp_path, monkeypatch):
+    target = tmp_path / "settings" / "mine.json"
+    monkeypatch.setattr(config_settings, "_DEFAULT_CONFIG_LOCATIONS", (target, target))
+
+    config = AppConfig(
+        dip=DIPConfig(api_key="ABC123", page_size=25),
+        gemini=GeminiConfig(api_key=None, model="gemini-demo"),
+        storage=StorageConfig(database_url="sqlite:///demo.db", echo_sql=True),
+    )
+
+    saved_path = save_config(config)
+    assert saved_path == target
+    data = json.loads(target.read_text(encoding="utf8"))
+    assert data["dip"]["api_key"] == "ABC123"
+    assert data["dip"]["page_size"] == 25
+    assert data["gemini"]["model"] == "gemini-demo"
+    assert data["storage"]["database_url"] == "sqlite:///demo.db"
+    assert data["storage"]["echo_sql"] is True


### PR DESCRIPTION
## Summary
- add helper functions to resolve and persist configuration files and expose them via the package interface
- extend the NiceGUI control center with a configuration editor, save/reload workflows, and dynamic storage recreation
- refresh CLI wiring, documentation, and tests to reflect the new UI-based configuration flow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca9efe9ad4832299098beb142db2a9